### PR TITLE
task-NXP-32300-disable-nuxeo-explorer-export-upload-failure-notifications

### DIFF
--- a/Jenkinsfiles/explorer/export.groovy
+++ b/Jenkinsfiles/explorer/export.groovy
@@ -219,7 +219,10 @@ pipeline {
     }
     unsuccessful {
       script {
-        nxSlack.error(message: "Failed to <${BUILD_URL}|upload> nuxeo-explorer reference export for ${NUXEO_VERSION}")
+        // TODO NXP-32209
+        if (isNuxeoPromoted(NUXEO_VERSION)) {
+          nxSlack.error(message: "Failed to <${BUILD_URL}|upload> nuxeo-explorer reference export for ${NUXEO_VERSION}")
+        }
       }
     }
   }


### PR DESCRIPTION
This has been tested in replay with `NUXEO_VERSION=2023.7.5` for silence: 
https://jenkins.platform.dev.nuxeo.com/job/explorer/job/export-platform-explorer-reference/455/consoleText
(454 was good but I forgot to put the right error log message so it was contradictory)

Test for wanted notification with `NUXEO_VERSION=2023.7`:
https://jenkins.platform.dev.nuxeo.com/job/explorer/job/export-platform-explorer-reference/453/consoleText
