### PR TITLE
task-NXP-32344-disable-unwanted-beta-Explorer-notifications

### DIFF
--- a/Jenkinsfiles/explorer/cleanup-exports.groovy
+++ b/Jenkinsfiles/explorer/cleanup-exports.groovy
@@ -26,6 +26,10 @@ library identifier: "platform-ci-shared-library@v0.0.26"
 * Triggered daily by a cron.
 */
 
+boolean isExplorerBeta(explorerUrl) {
+  return explorerUrl.contains("beta")
+}
+
 pipeline {
   agent {
     label 'jenkins-base'
@@ -101,7 +105,10 @@ pipeline {
   post {
     unsuccessful {
       script {
-        nxSlack.error(message: "Failed to cleanup old exports on ${params.TARGET_URL}: <${BUILD_URL}|#${BUILD_NUMBER}>")
+        // TODO NXP-32209
+        if (!isExplorerBeta(params.TARGET_URL)) {
+          nxSlack.error(message: "Failed to cleanup old exports on ${params.TARGET_URL}: <${BUILD_URL}|#${BUILD_NUMBER}>")
+        }
       }
     }
   }


### PR DESCRIPTION
The clean up doesn't have a `NUXEO_VERSION` to discriminate the runs. It's only there to remove exports based on `nxdistribution:aliases`

The list of jobs I have evaluated is commented in the ticket NXP-32344

Tested manually [here](https://jenkins.platform-staging.dev.nuxeo.com/blue/organizations/jenkins/explorer%2Fcleanup-exports/detail/cleanup-exports/6/pipeline/)

The unsuccessful clause was replayed like so:
```
    unsuccessful {
      script {
        echo "should be printed, isExplorerBeta: " + isExplorerBeta(params.TARGET_URL)
        echo "should be printed, and about the production url, isExplorerBeta: " + isExplorerBeta("https://explorer.nuxeo.com/nuxeo/site/distribution/")
        // TODO NXP-32209
        if (!isExplorerBeta(params.TARGET_URL)) {
          echo "should not be printed"
          nxSlack.error(message: "Failed to cleanup old exports on ${params.TARGET_URL}: <${BUILD_URL}|#${BUILD_NUMBER}>")
        }
      }
    }
```
output
```
17:33:22  should be printed, isExplorerBeta: true
17:33:22  should be printed, and about the production url, isExplorerBeta: false
```