### PR TITLE
NXBT-3878: Always allow executing unsuccessful post condition

### DIFF
--- a/Jenkinsfiles/nev/deploy-preview.groovy
+++ b/Jenkinsfiles/nev/deploy-preview.groovy
@@ -68,11 +68,11 @@ boolean isPRVersion(version) {
 
 String getMarkdownVersions() {
   return """
-- NEV Helm chart: `${NEV_CHART_VERSION}`
-- ARender Nuxeo: `${ARENDER_NUXEO_VERSION}`
-- Nuxeo Helm chart: `${NUXEO_CHART_VERSION}`
-- Nuxeo: `${NUXEO_VERSION}`
-- Nuxeo ARender connector: `${NUXEO_ARENDER_CONNECTOR_VERSION}`
+- NEV Helm chart: `${env.NEV_CHART_VERSION}`
+- ARender Nuxeo: `${env.ARENDER_NUXEO_VERSION}`
+- Nuxeo Helm chart: `${env.NUXEO_CHART_VERSION}`
+- Nuxeo: `${env.NUXEO_VERSION}`
+- Nuxeo ARender connector: `${env.NUXEO_ARENDER_CONNECTOR_VERSION}`
 """
 }
 


### PR DESCRIPTION
When the build is failing in the "Init versions" stage and some env vars expected by the post condition are unset, we get:
```
Error when executing unsuccessful post condition:
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 65eb0f8e-cfc5-4d1a-aa60-d96bfc7451eb
groovy.lang.MissingPropertyException: No such property: NUXEO_VERSION for class: groovy.lang.Binding
	at groovy.lang.Binding.getVariable(Binding.java:63)
	at PluginClassLoader for script-security//org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:285)
```